### PR TITLE
Remove extraneous newline character from Content-MD5 header

### DIFF
--- a/httpie_hmac_auth.py
+++ b/httpie_hmac_auth.py
@@ -36,7 +36,7 @@ class HmacAuth:
             if content_type:
                 m = hashlib.md5()
                 m.update(r.body)
-                content_md5 = base64.encodestring(m.digest())
+                content_md5 = base64.encodestring(m.digest()).rstrip()
                 r.headers['Content-MD5'] = content_md5
             else:
                 content_md5 = ''


### PR DESCRIPTION
This was causing `POST` and `PUT` to fail in certain circumstances. Required [wireshark](https://www.wireshark.org/) to troubleshoot.
